### PR TITLE
CPASS-464: Fix error when trying to load without any wallet extensions

### DIFF
--- a/packages/rainbowkit-wallet-adapter/src/eip113Wallet.ts
+++ b/packages/rainbowkit-wallet-adapter/src/eip113Wallet.ts
@@ -14,9 +14,6 @@ export class EIP1193Wallet implements Wallet {
   readonly #provider: Ethereum | undefined = undefined;
 
   constructor(ethereumProvider: Ethereum | undefined) {
-    if (!ethereumProvider) {
-      throw new Error("Ethereum Provider is required!");
-    }
     this.#provider = ethereumProvider;
   }
 


### PR DESCRIPTION
Don't assume we will have an eth provider since a user without any eth extensions or in incognito mode may not have one.

<img width="1212" alt="Screenshot 2023-06-14 at 10 09 02" src="https://github.com/civicteam/civic-multichain-connect-react/assets/4146605/c343745d-3fc5-43db-a2ec-06900ce2e437">
