### PR TITLE
CPASS-462 - Remove initial chain from top-level provider

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@civic/multichain-connect-react-core",
-  "version": "0.0.5",
+  "version": "0.0.6-beta.1",
   "description": "A multichain wallet connect library",
   "repository": "git@github.com:civicteam/civic-multichain-connect-react.git",
   "author": "civic.com",

--- a/packages/core/src/MultichainSelectorProvider.tsx
+++ b/packages/core/src/MultichainSelectorProvider.tsx
@@ -18,27 +18,12 @@ export default function ChainSelectorModalProvider<
   T extends SupportedChains,
   S extends BaseChain,
   E extends BaseChain
->({
-  children,
-  initialChain,
-}: {
-  children: React.ReactNode;
-  initialChain?: BaseChain;
-}): ReactElement {
+>({ children }: { children: React.ReactNode }): ReactElement {
   const [visible, setVisible] = useState(false);
   const [selectedChain, setSelectedChain] = useState<Chain<T, S, E>>();
   const [chains, setChains] = useState<Chain<T, S, E>[]>([]);
 
   const openChainModal = useCallback(() => {
-    // If initialChain is set, we want to select that chain and hide the chain selector dialog
-    if (initialChain) {
-      const chain: Chain<SupportedChains.Solana, BaseChain, never> = {
-        ...initialChain,
-      };
-      onChainSelect(chain as Chain<T, S, E>);
-      return;
-    }
-
     // Group the chains by chain type
     const groupedChains: Record<string, Array<any>> = chains.length
       ? groupBy((c) => c.type, chains)
@@ -59,7 +44,7 @@ export default function ChainSelectorModalProvider<
     }
 
     setVisible(true);
-  }, [chains, selectedChain, initialChain]);
+  }, [chains, selectedChain]);
 
   // Replace all chains of the same type with the new set of chains
   const setChainsByType = useCallback(
@@ -79,18 +64,10 @@ export default function ChainSelectorModalProvider<
       openChainModal,
       selectedChain,
       setSelectedChain,
-      initialChain,
       chains,
       setChains: setChainsByType,
     }),
-    [
-      chains,
-      openChainModal,
-      selectedChain,
-      setChains,
-      setSelectedChain,
-      initialChain,
-    ]
+    [chains, openChainModal, selectedChain, setChains, setSelectedChain]
   );
 
   const onClose = useCallback(() => {

--- a/packages/core/src/MultichainWalletProvider.tsx
+++ b/packages/core/src/MultichainWalletProvider.tsx
@@ -6,21 +6,19 @@ import { defaultLabels } from "./constants.js";
 import LabelProvider from "./MultichainLabelProvider.js";
 import MultichainWalletAdapterPluginProvider from "./MultichainWalletAdapterPluginProvider.js";
 import MultichainWalletDisconnectProvider from "./MultichainWalletDisconnectProvider.js";
-import { BaseChain, Labels } from "./types.js";
+import { Labels } from "./types.js";
 
 export default function MultichainWalletProvider({
   children,
   labels,
-  initialChain,
 }: {
   children?: React.ReactNode;
   labels?: Labels;
-  initialChain?: BaseChain;
 }): ReactElement {
   return (
     <LabelProvider labels={labels}>
       <WalletStandardProvider>
-        <ChainSelectorModalProvider initialChain={initialChain}>
+        <ChainSelectorModalProvider>
           <MultichainWalletAdapterPluginProvider>
             <MultichainWalletDisconnectProvider>
               {children}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -29,4 +29,4 @@ export {
   SupportedChains,
 };
 
-export type { Chain, WalletContextType, ModalContextType, BaseChain };
+export type { Chain, BaseChain, WalletContextType, ModalContextType };

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -51,7 +51,6 @@ export interface ChainContextType<
   setSelectedChain: (chain?: Chain<T, S, E>) => void;
   openChainModal: (() => void) | undefined;
   setChains: (chains: Chain<T, S, E>[], type: SupportedChains) => void;
-  initialChain?: BaseChain;
 }
 
 export interface ModalContextType {

--- a/packages/examples/advanced-react/package.json
+++ b/packages/examples/advanced-react/package.json
@@ -10,35 +10,36 @@
     "eject": "react-scripts eject"
   },
   "dependencies": {
-    "react": "^18.0.2",
-    "react-dom": "^18.0.2",
-    "react-scripts": "^5.0.1",
-    "typescript": "^4.8.4",
-    "react-app-rewired": "^2.2.1",
     "@civic/multichain-connect-react-core": "workspace:^",
-    "@civic/multichain-connect-react-solana-wallet-adapter": "workspace:^",
     "@civic/multichain-connect-react-rainbowkit-wallet-adapter": "workspace:^",
-    "assert": "^2.0.0",
-    "buffer": "^6.0.3",
-    "process": "^0.11.10",
-    "url": "^0.11.0",
-    "wagmi": "0.12.17",
+    "@civic/multichain-connect-react-solana-wallet-adapter": "workspace:^",
     "@solana/wallet-adapter-base": "^0.9.22",
     "@solana/wallet-adapter-react": "^0.15.32",
     "@solana/web3.js": "^1.76.0",
-    "styled-components": "^6.0.0-rc.3"
+    "assert": "^2.0.0",
+    "buffer": "^6.0.3",
+    "ethers": "^5.7.2",
+    "process": "^0.11.10",
+    "react": "^18.0.2",
+    "react-app-rewired": "^2.2.1",
+    "react-dom": "^18.0.2",
+    "react-scripts": "^5.0.1",
+    "styled-components": "^6.0.0-rc.3",
+    "typescript": "^4.8.4",
+    "url": "^0.11.0",
+    "wagmi": "0.12.17"
   },
   "devDependencies": {
     "@babel/core": "^7.22.1",
-    "@types/react": "^18.2.0",
+    "@babel/plugin-proposal-private-property-in-object": "^7.14.5",
     "@types/node": "^18.7.23",
+    "@types/react": "^18.2.0",
     "@types/react-dom": "^18.0.0",
-    "os-browserify": "^0.3.0",
-    "path-browserify": "^1.0.1",
-    "stream-browserify": "^3.0.0",
     "constants-browserify": "^1.0.0",
     "crypto-browserify": "^3.12.0",
-    "@babel/plugin-proposal-private-property-in-object": "^7.14.5"
+    "os-browserify": "^0.3.0",
+    "path-browserify": "^1.0.1",
+    "stream-browserify": "^3.0.0"
   },
   "browserslist": {
     "production": [

--- a/packages/examples/advanced-react/src/App.tsx
+++ b/packages/examples/advanced-react/src/App.tsx
@@ -106,6 +106,7 @@ function App() {
       return chain.name.toLowerCase() === name;
     };
 
+  // If the url contains a hash, filter the chains to only show the selected chain for evm
   useEffect(() => {
     if (!hash) return;
 
@@ -131,7 +132,6 @@ function App() {
     );
   }, [hash]);
 
-  // If the url contains a hash, filter the chains to only show the selected chain for evm
   useEffect(() => {
     if (hash) return;
 
@@ -155,7 +155,7 @@ function App() {
             providers={[publicProvider()]}
             options={{
               // Rainbowkit relies on WalletConnect which now needs to obtain a projectId from WalletConnect Cloud.
-              walletConnectProjectId: "1234",
+              walletConnectProjectId: "*YOUR WALLET CONNECT PROJECT ID*",
             }}
             initialChain={initialChain}
           >

--- a/packages/examples/advanced-react/src/App.tsx
+++ b/packages/examples/advanced-react/src/App.tsx
@@ -11,12 +11,10 @@ import { clusterApiUrl } from "@solana/web3.js";
 import {
   Chain as SolanaChain,
   SolanaWalletAdapterConfig,
-  useSolanaWalletAdapterProvider,
 } from "@civic/multichain-connect-react-solana-wallet-adapter";
 import {
   Chain as EthereumChain,
   RainbowkitConfig,
-  useRainbowkitWalletAdapterProvider,
 } from "@civic/multichain-connect-react-rainbowkit-wallet-adapter";
 import { publicProvider } from "wagmi/providers/public";
 import {
@@ -29,6 +27,7 @@ import {
 } from "wagmi/chains";
 import { useHash } from "./hooks/useHash";
 import styled from "styled-components";
+import { useMultiWallet } from "./hooks/useWallet";
 
 const StyledTableHeader = styled.th`
   padding: 0 10px;
@@ -39,23 +38,7 @@ const StyledTableData = styled.td`
 `;
 
 function Content() {
-  const [evmAddress, setEvmAddress] = useState<string | undefined>();
-
-  const solanaWallet = useSolanaWalletAdapterProvider();
-  const evmWallet = useRainbowkitWalletAdapterProvider();
-
-  useEffect(() => {
-    const fetchAddress = async () => {
-      const address = await evmWallet.wallet?.getAddress();
-      setEvmAddress(address);
-    };
-
-    if (evmWallet && evmWallet.connected) {
-      fetchAddress();
-    } else {
-      setEvmAddress(undefined);
-    }
-  }, [evmWallet]);
+  const { solanaWallet, ethersWallet, address } = useMultiWallet();
 
   return (
     <table style={{ marginTop: "20px" }}>
@@ -70,20 +53,16 @@ function Content() {
         <tr>
           <StyledTableData>Solana</StyledTableData>
           <StyledTableData>
-            {solanaWallet && solanaWallet.connected
-              ? "Connected"
-              : "Not Connected"}
+            {solanaWallet ? "Connected" : "Not Connected"}
           </StyledTableData>
-          <StyledTableData>
-            {solanaWallet?.wallet?.publicKey?.toBase58() || "N/A"}
-          </StyledTableData>
+          <StyledTableData>{solanaWallet ? address : "N/A"}</StyledTableData>
         </tr>
         <tr>
           <StyledTableData>EVM</StyledTableData>
           <StyledTableData>
-            {evmWallet && evmWallet.connected ? "Connected" : "Not Connected"}
+            {ethersWallet ? "Connected" : "Not Connected"}
           </StyledTableData>
-          <StyledTableData>{evmAddress || "N/A"}</StyledTableData>
+          <StyledTableData>{ethersWallet ? address : "N/A"}</StyledTableData>
         </tr>
       </tbody>
     </table>
@@ -107,81 +86,78 @@ function App() {
   const defaultSolanaTestChains = [solanaDevnetChain];
 
   const { hash } = useHash();
-  const [initialChain, setInitialChain] = useState<BaseChain | undefined>(
+
+  const [initialChain, setInitialChain] = useState<EthereumChain | undefined>(
     undefined
   );
+
   const [evmChains, setEvmChains] = useState<{
     chains: EthereumChain[];
     testChains: EthereumChain[];
   }>({ chains: defaultEvmChains, testChains: defaultEvmTestChains });
+
   const [solanaChains, setSolanaChains] = useState<{
     chains: SolanaChain[];
     testChains: SolanaChain[];
   }>({ chains: defaultSolanaChains, testChains: defaultSolanaTestChains });
 
-  // If the url contains a hash, filter the chains to only show the selected chain for evm
+  const filterChain =
+    (name: string) => (chain: EthereumChain | SolanaChain) => {
+      return chain.name.toLowerCase() === name;
+    };
+
   useEffect(() => {
-    if (!hash) {
-      setEvmChains({
-        chains: defaultEvmChains,
-        testChains: defaultEvmTestChains,
-      });
-      setSolanaChains({
-        chains: defaultSolanaChains,
-        testChains: defaultSolanaTestChains,
-      });
-      return;
-    }
+    if (!hash) return;
 
     const decodedKey = decodeURIComponent(hash);
     const formattedChainName =
       decodedKey.charAt(0).toUpperCase() + decodedKey.slice(1);
     document.title = `Sample: ${formattedChainName}`;
 
-    const selectedEvmChain = [
-      ...defaultEvmChains,
-      ...defaultEvmTestChains,
-    ].filter((c) => c.name.toLowerCase() === decodedKey)[0];
-    if (selectedEvmChain) {
-      setInitialChain({ ...selectedEvmChain, type: SupportedChains.Ethereum });
-      setEvmChains({
-        chains: defaultEvmChains,
-        testChains: defaultEvmTestChains,
-      });
-      setSolanaChains({ chains: [], testChains: [] });
-      return;
-    }
+    setEvmChains({
+      chains: defaultEvmChains.filter(filterChain(decodedKey)),
+      testChains: defaultEvmTestChains.filter(filterChain(decodedKey)),
+    });
 
-    const selectedSolanaChain = [
-      ...defaultSolanaChains,
-      ...defaultSolanaTestChains,
-    ].filter((c) => c.name.toLowerCase() === decodedKey)[0];
-    if (selectedSolanaChain) {
-      setInitialChain({ ...selectedSolanaChain, type: SupportedChains.Solana });
-      setSolanaChains({
-        chains: defaultSolanaChains,
-        testChains: defaultSolanaTestChains,
-      });
-      setEvmChains({ chains: [], testChains: [] });
-      return;
-    }
+    setSolanaChains({
+      chains: defaultSolanaChains.filter(filterChain(decodedKey)),
+      testChains: defaultSolanaTestChains.filter(filterChain(decodedKey)),
+    });
 
-    setEvmChains({ chains: [], testChains: [] });
-    setSolanaChains({ chains: [], testChains: [] });
+    setInitialChain(
+      [...defaultEvmChains, ...defaultEvmTestChains].find(
+        filterChain(decodedKey)
+      )
+    );
+  }, [hash]);
+
+  // If the url contains a hash, filter the chains to only show the selected chain for evm
+  useEffect(() => {
+    if (hash) return;
+
+    setEvmChains({
+      chains: defaultEvmChains,
+      testChains: defaultEvmTestChains,
+    });
+    setSolanaChains({
+      chains: defaultSolanaChains,
+      testChains: defaultSolanaTestChains,
+    });
   }, [hash]);
 
   return (
     <div className="App">
       <header className="App-header">
-        <MultichainWalletProvider initialChain={initialChain}>
+        <MultichainWalletProvider>
           <RainbowkitConfig
             chains={evmChains.chains}
             testnetChains={evmChains.testChains}
             providers={[publicProvider()]}
             options={{
               // Rainbowkit relies on WalletConnect which now needs to obtain a projectId from WalletConnect Cloud.
-              walletConnectProjectId: "*YOUR WALLET CONNECT PROJECT ID*",
+              walletConnectProjectId: "1234",
             }}
+            initialChain={initialChain}
           >
             <SolanaWalletAdapterConfig
               chains={solanaChains.chains}

--- a/packages/examples/advanced-react/src/hooks/useWallet.ts
+++ b/packages/examples/advanced-react/src/hooks/useWallet.ts
@@ -1,0 +1,52 @@
+import {
+  SupportedChains,
+  useWallet,
+} from "@civic/multichain-connect-react-core";
+import { WalletContextState } from "@solana/wallet-adapter-react";
+import { Wallet as EthersWallet } from "ethers";
+import { useState, useEffect } from "react";
+
+export interface MultiWalletContextState {
+  connected: boolean;
+  solanaWallet?: WalletContextState;
+  ethersWallet?: EthersWallet;
+  address?: string;
+}
+
+export const useMultiWallet = (): MultiWalletContextState => {
+  const [address, setAddress] = useState<string | undefined>(undefined);
+  const { connected } = useWallet();
+
+  const { wallet: solanaWallet } = useWallet<
+    SupportedChains.Solana,
+    WalletContextState,
+    never
+  >();
+
+  const { wallet: ethersWallet } = useWallet<
+    SupportedChains.Ethereum,
+    never,
+    EthersWallet
+  >();
+
+  useEffect(() => {
+    if (solanaWallet?.publicKey) {
+      setAddress(solanaWallet.publicKey.toBase58());
+    }
+  }, [solanaWallet]);
+
+  useEffect(() => {
+    if (ethersWallet?.getAddress) {
+      ethersWallet?.getAddress().then((address) => {
+        setAddress(address);
+      });
+    }
+  }, [ethersWallet]);
+
+  return {
+    connected,
+    address,
+    solanaWallet: solanaWallet?.publicKey ? solanaWallet : undefined,
+    ethersWallet: ethersWallet?.getAddress ? ethersWallet : undefined,
+  };
+};

--- a/packages/rainbowkit-wallet-adapter/package.json
+++ b/packages/rainbowkit-wallet-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@civic/multichain-connect-react-rainbowkit-wallet-adapter",
-  "version": "0.0.5",
+  "version": "0.0.6-beta.1",
   "description": "A multichain wallet connect library",
   "repository": "git@github.com:civicteam/civic-multichain-connect-react.git",
   "author": "civic.com",

--- a/packages/rainbowkit-wallet-adapter/src/RainbowkitConfig.tsx
+++ b/packages/rainbowkit-wallet-adapter/src/RainbowkitConfig.tsx
@@ -60,20 +60,24 @@ function RainbowkitConfig({
   testnetChains,
   providers,
   options,
+  initialChain,
 }: {
   children?: React.ReactNode;
   theme?: Theme | null;
   providers?: ChainProviderFn[];
+  initialChain?: Chain;
   chains: Chain[];
   testnetChains?: Chain[];
   options: RainbowkitConfigOptions;
 }): JSX.Element | null {
   const { labels } = useLabel();
-  const { setChains, selectedChain, initialChain } = useChain<
+
+  const { setChains, selectedChain } = useChain<
     SupportedChains.Ethereum,
     never,
     Chain & BaseChain
   >();
+
   const [evmInitialChain, setEvmInitialChain] = React.useState<
     Chain | undefined
   >(undefined);

--- a/packages/rainbowkit-wallet-adapter/src/RainbowkitWalletProvider.tsx
+++ b/packages/rainbowkit-wallet-adapter/src/RainbowkitWalletProvider.tsx
@@ -1,12 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { Wallet } from "ethers";
-import React, {
-  ReactElement,
-  useContext,
-  useEffect,
-  useMemo,
-  useState,
-} from "react";
+import React, { ReactElement, useEffect, useMemo, useState } from "react";
 import { useAccount, useDisconnect, useNetwork, useSwitchNetwork } from "wagmi";
 import {
   SupportedChains,
@@ -82,6 +76,3 @@ export default function RainbowkitWalletProvider({
     </RainbowkitWalletContext.Provider>
   );
 }
-
-export const useRainbowkitWalletAdapterProvider = () =>
-  useContext(RainbowkitWalletContext);

--- a/packages/rainbowkit-wallet-adapter/src/index.ts
+++ b/packages/rainbowkit-wallet-adapter/src/index.ts
@@ -1,8 +1,6 @@
 import RainbowkitConfig from "./RainbowkitConfig.js";
 import { Chain, RainbowkitConfigOptions } from "./types.js";
-import { useRainbowkitWalletAdapterProvider } from "./RainbowkitWalletProvider.js";
 
 export { RainbowkitConfig };
 export type { Chain };
 export type { RainbowkitConfigOptions };
-export { useRainbowkitWalletAdapterProvider };

--- a/packages/solana-wallet-adapter/package.json
+++ b/packages/solana-wallet-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@civic/multichain-connect-react-solana-wallet-adapter",
-  "version": "0.0.5",
+  "version": "0.0.6-beta.1",
   "description": "A multichain wallet connect library",
   "repository": "git@github.com:civicteam/civic-multichain-connect-react.git",
   "author": "civic.com",

--- a/packages/solana-wallet-adapter/src/SolanaWalletAdapterConfig.tsx
+++ b/packages/solana-wallet-adapter/src/SolanaWalletAdapterConfig.tsx
@@ -70,14 +70,12 @@ function SolanaWalletAdapterConfig({
     Chain & BaseChain,
     never
   >();
+
   const endpoint = useMemo(() => {
     if (chains.length === 0 || !selectedChain?.rpcEndpoint) {
       return DEFAULT_ENDPOINT;
     }
-
-    const rpcEndpoint = selectedChain?.rpcEndpoint;
-
-    return rpcEndpoint;
+    return selectedChain?.rpcEndpoint;
   }, [chains, selectedChain]);
 
   const wallets = useMemo(

--- a/packages/solana-wallet-adapter/src/SolanaWalletAdapterConfig.tsx
+++ b/packages/solana-wallet-adapter/src/SolanaWalletAdapterConfig.tsx
@@ -13,6 +13,7 @@ import {
   PhantomWalletAdapter,
   SolflareWalletAdapter,
   TorusWalletAdapter,
+  WalletConnectWalletAdapter,
 } from "@solana/wallet-adapter-wallets";
 import SolanaWalletAdapterModalProvider, {
   SolanaWalletAdapterModalContext,
@@ -28,7 +29,12 @@ import {
 } from "@civic/multichain-connect-react-core";
 import { SolanaWalletAdapterButton } from "./SolanaWalletAdapterButton.js";
 import "@solana/wallet-adapter-react-ui/styles.css";
-import { Chain, DEFAULT_ENDPOINT } from "./types.js";
+import {
+  Chain,
+  DEFAULT_ENDPOINT,
+  SolanaConfigOptions,
+  WalletAdapterNetwork,
+} from "./types.js";
 
 function SolanaWalletAdapterPluginProvider<T>({
   children,
@@ -59,10 +65,12 @@ function SolanaWalletAdapterConfig({
   children,
   chains,
   testnetChains,
+  options,
 }: {
   children?: React.ReactNode;
   chains: Chain[];
   testnetChains?: Chain[];
+  options: SolanaConfigOptions;
 }): JSX.Element | null {
   // For now support only a single chain
   const { setChains, selectedChain } = useChain<
@@ -78,6 +86,12 @@ function SolanaWalletAdapterConfig({
     return selectedChain?.rpcEndpoint;
   }, [chains, selectedChain]);
 
+  const network = useMemo(() => {
+    return endpoint.includes("mainnet")
+      ? WalletAdapterNetwork.Mainnet
+      : WalletAdapterNetwork.Devnet;
+  }, [endpoint]);
+
   const wallets = useMemo(
     () => [
       new PhantomWalletAdapter(),
@@ -87,6 +101,10 @@ function SolanaWalletAdapterConfig({
       new BackpackWalletAdapter(),
       new GlowWalletAdapter(),
       new ExodusWalletAdapter(),
+      new WalletConnectWalletAdapter({
+        options: { projectId: options.walletConnectProjectId },
+        network,
+      }),
       new TorusWalletAdapter(),
     ],
     []

--- a/packages/solana-wallet-adapter/src/SolanaWalletAdapterModalProvider.tsx
+++ b/packages/solana-wallet-adapter/src/SolanaWalletAdapterModalProvider.tsx
@@ -18,15 +18,11 @@ export default function SolanaWalletAdapterModalProvider({
 }): ReactElement {
   const { wallet } = useWallet();
   const { setVisible } = useWalletModal();
-  const { selectedChain, initialChain } = useChain();
+  const { selectedChain } = useChain();
 
   const openConnectModal = useCallback(() => {
-    // Don't show modal if initial chain is set to a solana one
-    if (initialChain?.type === SupportedChains.Solana) {
-      return;
-    }
     setVisible(true);
-  }, [setVisible, initialChain]);
+  }, [setVisible]);
 
   useEffect(() => {
     if (!wallet?.adapter.publicKey) {

--- a/packages/solana-wallet-adapter/src/SolanaWalletAdapterProvider.tsx
+++ b/packages/solana-wallet-adapter/src/SolanaWalletAdapterProvider.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import React, { ReactElement, useContext, useEffect, useMemo } from "react";
+import React, { ReactElement, useEffect, useMemo } from "react";
 import { useWallet } from "@solana/wallet-adapter-react";
 import {
   BaseChain,
@@ -15,6 +15,7 @@ export const SolanaProviderContext = {} as WalletContextType<
   any,
   never
 > & { connection: Connection | undefined };
+
 export const SolanaWalletAdapterContext = React.createContext<
   WalletContextType<any, any, never> & { connection: Connection | undefined }
 >(SolanaProviderContext);
@@ -27,7 +28,7 @@ export default function SolanaWalletAdapterProvider({
 }): ReactElement {
   const adapter = useWallet();
   const { wallet, connected, disconnect, publicKey } = adapter;
-  const { setSelectedChain, selectedChain, chains, initialChain } = useChain<
+  const { setSelectedChain, selectedChain, chains } = useChain<
     SupportedChains.Solana,
     Chain & BaseChain,
     never
@@ -37,7 +38,7 @@ export default function SolanaWalletAdapterProvider({
     return selectedChain?.rpcEndpoint
       ? new Connection(selectedChain?.rpcEndpoint)
       : undefined;
-  }, [selectedChain?.rpcEndpoint, initialChain]);
+  }, [selectedChain?.rpcEndpoint]);
 
   const context = useMemo(
     () => ({
@@ -60,23 +61,10 @@ export default function SolanaWalletAdapterProvider({
       const chain = chains
         .filter((c) => c.type === SupportedChains.Solana)
         .filter((c) => c.rpcEndpoint === connection?.rpcEndpoint);
+
       if (selectedChain?.name !== chain[0]?.name) {
         setSelectedChain(chain[0]);
         return;
-      }
-      // If we're refreshing while a wallet was connected
-      if (!selectedChain && wallet?.adapter.publicKey && connected) {
-        // If an initialChain was set then selectedChain will be lost, so reinstate it
-        if (initialChain) {
-          const chain = chains
-            .filter((c) => c.type === SupportedChains.Solana)
-            .filter((c) => c.name === initialChain.name);
-          setSelectedChain(chain[0]);
-        }
-        // Else we disconnect the wallet
-        else {
-          disconnect();
-        }
       }
     }
   }, [
@@ -94,6 +82,3 @@ export default function SolanaWalletAdapterProvider({
     </SolanaWalletAdapterContext.Provider>
   );
 }
-
-export const useSolanaWalletAdapterProvider = () =>
-  useContext(SolanaWalletAdapterContext);

--- a/packages/solana-wallet-adapter/src/index.ts
+++ b/packages/solana-wallet-adapter/src/index.ts
@@ -1,7 +1,5 @@
 import SolanaWalletAdapterConfig from "./SolanaWalletAdapterConfig.js";
 import { Chain } from "./types.js";
-import { useSolanaWalletAdapterProvider } from "./SolanaWalletAdapterProvider.js";
 
 export { SolanaWalletAdapterConfig };
 export type { Chain };
-export { useSolanaWalletAdapterProvider };

--- a/packages/solana-wallet-adapter/src/types.ts
+++ b/packages/solana-wallet-adapter/src/types.ts
@@ -7,3 +7,13 @@ export type Chain = {
 };
 
 export const DEFAULT_ENDPOINT = clusterApiUrl("mainnet-beta");
+
+export type SolanaConfigOptions = {
+  walletConnectProjectId: string;
+};
+
+export enum WalletAdapterNetwork {
+  Mainnet = "mainnet-beta",
+  Testnet = "testnet",
+  Devnet = "devnet",
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.1'
+lockfileVersion: '6.0'
 
 settings:
   autoInstallPeers: true
@@ -144,6 +144,9 @@ importers:
       buffer:
         specifier: ^6.0.3
         version: 6.0.3
+      ethers:
+        specifier: ^5.7.2
+        version: 5.7.2
       process:
         specifier: ^0.11.10
         version: 0.11.10


### PR DESCRIPTION
There was a bug where the wallet would disconnect if the initial chain was not set. Since the Chain type is fundamentally different between the chains, I don't think we should expose the BaseChain used internally to the integrator.

Rainbowkit will connect to the first chain in your chains array to ensure users are not immediately presented with the "Wrong network" state. You can override this behavior by setting the initialChain.

The Solana Wallet adapter does not support multiple chains; it only accepts a single object. If multiple chains are passed into the Multchain Connect Solana Provider, the chain Modal will be shown. Therefore, I am not sure of the purpose of having an initial chain for the provider.

The primary purpose of the library is to allow users to work seamlessly between different wallets. Unfortunately, due to completely different interfaces of the wallets, it is difficult to determine which wallet the user has connected with. However, this shouldn't prevent us from having a single provider with a common interface. The user can specify the wallet type though. You can refer to the [following hook](https://github.com/civicteam/civic-multichain-connect-react/pull/34/files#diff-21432c93b41772a6433abb25649a48bca310e4c61152bf83ff3f3b0a8f64ba26R20). Though not ideal, it is still better than having multiple wallet providers.

https://github.com/civicteam/civic-multichain-connect-react/assets/1284501/74bee431-ffdd-455c-b3bf-7eca4064e4e3



- CPASS-462 - Remove initial chain from top level provider
- CPASS-462 - Publish multichain libraries
